### PR TITLE
Bump version to 1.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tagelect",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Tag input field with autocomplete and validations.",
   "main": "./dist/tagelect.js",
   "files": [


### PR DESCRIPTION
Looks like version 1.0.1 might have been published to NPM from
master branch before the v1.0.1 branch had been merged in master.

This commit and branch contains no changes, except for bumped version.